### PR TITLE
Linkedin provider fix for Error: API Key is invalid.

### DIFF
--- a/src/entities/base-login-provider.ts
+++ b/src/entities/base-login-provider.ts
@@ -15,7 +15,7 @@ export abstract class BaseLoginProvider implements LoginProvider {
     signInJS.async = true;
     signInJS.src = obj.url;
     signInJS.onload = onload;
-    if (obj.name === 'LINKEDIN') {
+    if (obj.name === 'linkedin') {
       signInJS.async = false;
       signInJS.text = ('api_key: ' + obj.id).replace('\'', '');
     }


### PR DESCRIPTION
Linkedin provider fix for Error: API Key is invalid.

The error was uppercase strict validation (obj.name === 'linkedin')  now it's working.